### PR TITLE
feat: allow manually clearing the captured output

### DIFF
--- a/spock-outputcapture/src/main/java/io/github/joke/spockoutputcapture/CapturedOutput.java
+++ b/spock-outputcapture/src/main/java/io/github/joke/spockoutputcapture/CapturedOutput.java
@@ -9,4 +9,6 @@ public interface CapturedOutput {
 
     List<String> getLines();
 
+    void clear();
+
 }

--- a/spock-outputcapture/src/main/java/io/github/joke/spockoutputcapture/CapturedOutputImpl.java
+++ b/spock-outputcapture/src/main/java/io/github/joke/spockoutputcapture/CapturedOutputImpl.java
@@ -18,6 +18,11 @@ public class CapturedOutputImpl implements CapturedOutput {
         return asList(buffer.toString().split("(\\r\\n|\\n|\\r)"));
     }
 
+    @Override
+    public void clear() {
+        buffer.setLength(0);
+    }
+
     synchronized StringBuffer append(String str) {
         return buffer.append(str);
     }


### PR DESCRIPTION
Hey, first of all thank you very much for this little useful library.

I'm currently having a use case where I have to start the application multiple times in a single test and check the logs of the respective application runs individually.

Therefore, a way to manually clear the underlying buffer would be great.

Let me know what you think :)